### PR TITLE
Implement Wayland screencopy capture backend with pixel format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +212,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "endi"
@@ -272,6 +288,12 @@ name = "fastrand"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -398,9 +420,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -521,6 +543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -679,6 +716,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1025,6 +1068,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,10 +1263,14 @@ name = "xdg-desktop-portal-agl"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "libc",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ build = "build.rs"
 name = "xdg-desktop-portal-agl"
 path = "src/main.rs"
 
+[lib]
+name = "wayland_capture"
+path = "src/wayland_capture/lib.rs"
+
 [dependencies]
 zbus               = { version = "5.1.1", features = ["tokio"] }
 tokio              = { version = "1.50", features = ["full"] }
@@ -19,3 +23,7 @@ tracing            = "0.1"
 tracing-subscriber = "0.3"
 anyhow             = "1.0"
 thiserror          = "2.0"
+wayland-client = "0.31"
+wayland-protocols = { version = "0.31", features = ["client", "unstable"] }
+wayland-protocols-wlr = { version = "0.2", features = ["client"] }
+libc = "0.2.186"

--- a/src/wayland_capture/capture/mod.rs
+++ b/src/wayland_capture/capture/mod.rs
@@ -1,0 +1,260 @@
+pub mod types;
+
+use std::os::unix::io::{OwnedFd, AsRawFd, BorrowedFd, FromRawFd};
+use libc;
+use std::sync::{Arc, Mutex};
+
+use wayland_client::{
+    protocol::{
+        wl_buffer::WlBuffer,
+        wl_output::WlOutput,
+        wl_shm::{Format, WlShm},
+        wl_shm_pool::WlShmPool,
+    },
+    QueueHandle,
+};
+
+use wayland_protocols_wlr::screencopy::v1::client::{
+    zwlr_screencopy_frame_v1::{self, ZwlrScreencopyFrameV1},
+    zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1,
+};
+
+use types::CaptureError;
+use types::{PixelBuffer, PixelFormat, CaptureState};
+
+// Abstract API for Capture backend.
+pub trait CaptureBackend {
+    fn capture(
+        &mut self,
+        output: &WlOutput,
+        event_queue: &mut wayland_client::EventQueue<WlrScreencopyState>,
+    ) -> Result<PixelBuffer, CaptureError>;
+}
+
+// Dispatch state for the screencopy protocol.
+pub struct WlrScreencopyState {
+    pub state: Arc<Mutex<CaptureState>>,
+    pub shm: WlShm,
+}
+
+impl wayland_client::Dispatch<ZwlrScreencopyFrameV1, ()> for WlrScreencopyState {
+    fn event(
+        state: &mut Self,
+        _proxy: &ZwlrScreencopyFrameV1,
+        event: zwlr_screencopy_frame_v1::Event,
+        _data: &(),
+        _conn: &wayland_client::Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        use zwlr_screencopy_frame_v1::Event;
+        let mut state_lock = state.state.lock().unwrap();
+
+        match event {
+            Event::Buffer { format, width, height, stride} => {
+                let pixel_format = PixelFormat::from_raw(format.into());
+                let size = PixelBuffer::expected_size(stride, height).unwrap_or(0);
+                *state_lock = CaptureState::BufferAllocated {
+                    width,
+                    height,
+                    stride,
+                    format: pixel_format,
+                    data: vec![0u8; size],
+                };
+            }
+
+            Event::Ready { .. } => {
+                let prev = std::mem::replace(&mut *state_lock, CaptureState::Failed);
+                if let CaptureState::BufferAllocated { width, height, stride, format, data } = prev {
+                    let pixel_buffer = PixelBuffer {
+                        data,
+                        width,
+                        height,
+                        stride,
+                        format,
+                    };
+                    *state_lock = CaptureState::Ready(pixel_buffer);
+                } else {
+                    *state_lock = CaptureState::Failed;
+                }
+            }
+
+            Event::Failed => {
+                *state_lock = CaptureState::Failed;
+            }
+
+            Event::BufferDone => {}
+
+            _ => {}
+        }
+    }
+}
+
+impl wayland_client::Dispatch<WlShmPool, ()> for WlrScreencopyState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlShmPool,
+        _event: wayland_client::protocol::wl_shm_pool::Event,
+        _data: &(),
+        _conn: &wayland_client::Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        // No events to handle for WlShmPool in this context.
+    }
+}
+
+impl wayland_client::Dispatch<WlBuffer, ()> for WlrScreencopyState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlBuffer,
+        _event: wayland_client::protocol::wl_buffer::Event,
+        _data: &(),
+        _conn: &wayland_client::Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        // No events to handle for WlBuffer in this context.
+    }
+}
+
+impl wayland_client::Dispatch<WlShm, ()> for WlrScreencopyState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlShm,
+        _event: wayland_client::protocol::wl_shm::Event,
+        _data: &(),
+        _conn: &wayland_client::Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        // No events to handle for WlShm in this context.
+    }
+}
+
+/// Concrete implementation of the CaptureBackend trait for Wayland using the wlr-screencopy protocol.
+/// wlr-screencopy is a protocol extension for Wayland compositors that allows clients to capture the contents of outputs (screens) in a secure and efficient manner. This struct encapsulates the necessary Wayland objects and state to perform screen capture operations.
+/// It works for both wlroots-based compositors and agl-compositors.
+pub struct WlrScreencopy {
+    manager: ZwlrScreencopyManagerV1,
+    shm: WlShm,
+}
+
+impl WlrScreencopy {
+    pub fn new(manager: ZwlrScreencopyManagerV1, shm: WlShm) -> Self {
+        Self { manager, shm }
+    }
+
+    /// Allocate an anonymous shared memory file descriptor of the specified size using memfd_create, and return it as an OwnedFd. Returns an error if the allocation fails.
+    pub fn allocate_shm(size: usize) -> Result<(OwnedFd, *mut libc::c_void), CaptureError> {
+        use std::ffi::CStr;
+        let fd = unsafe {
+            libc::memfd_create(
+                CStr::from_bytes_with_nul(b"wl_shm\0").unwrap().as_ptr(),
+                libc::MFD_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(CaptureError::ShmAllocationFailed(std::io::Error::last_os_error()));
+        }
+        unsafe {
+            if libc::ftruncate(fd, size as libc::off_t) < 0 {
+                libc::close(fd);
+                return Err(CaptureError::ShmAllocationFailed(std::io::Error::last_os_error()));
+            }
+            let ptr = libc::mmap(
+                std::ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd,
+                0,
+            );
+            if ptr == libc::MAP_FAILED {
+                libc::close(fd);
+                return Err(CaptureError::ShmAllocationFailed(std::io::Error::last_os_error()));
+            }
+            Ok((OwnedFd::from_raw_fd(fd), ptr))
+        }
+    }
+}
+
+impl CaptureBackend for WlrScreencopy {
+    fn capture(
+        &mut self,
+        output: &WlOutput,
+        event_queue: &mut wayland_client::EventQueue<WlrScreencopyState>,
+    ) -> Result<PixelBuffer, CaptureError> {
+        let shared_state = Arc::new(Mutex::new(CaptureState::Pending));
+        let mut dispatch_state = WlrScreencopyState {
+            state: shared_state.clone(),
+            shm: self.shm.clone(),
+        };
+
+        let qh = event_queue.handle();
+        // request a frame, compositor will send buffer + buffer_done events, then ready or failed.
+        let frame = self.manager.capture_output(0, output, &qh, ());
+
+        event_queue.roundtrip(&mut dispatch_state).map_err(|e| CaptureError::WaylandError(e.to_string()))?;
+
+        // inspect to know dimensions
+        let (width, height, stride, format) = {
+            let state_lock = shared_state.lock().unwrap();
+            match &*state_lock {
+                CaptureState::BufferAllocated { width, height, stride, format, .. } => {
+                    (*width, *height, *stride, *format)
+                }
+                _ => return Err(CaptureError::CaptureFailed("Failed to allocate buffer".to_string())),
+            }
+        };
+
+        let size = PixelBuffer::expected_size(stride, height).ok_or(CaptureError::CaptureFailed("Buffer size overflow".to_string()))?;
+
+        let (fd, ptr) = Self::allocate_shm(size)?;
+
+        let borrowed_fd = unsafe {
+            BorrowedFd::borrow_raw(fd.as_raw_fd())
+        };
+
+        let pool = dispatch_state.shm.create_pool(borrowed_fd, size as i32, &qh, ());
+        let buffer = pool.create_buffer(
+            0,
+            width as i32,
+            height as i32,
+            stride as i32,
+            match format {
+                PixelFormat::Argb8888 => Format::Argb8888,
+                PixelFormat::Xrgb8888 => Format::Xrgb8888,
+                PixelFormat::Xbgr8888 => Format::Xbgr8888,
+                PixelFormat::Abgr8888 => Format::Abgr8888,
+                PixelFormat::Rgb565 => Format::Rgb565,
+                PixelFormat::Invalid | PixelFormat::Unknown(_) => return Err(CaptureError::CaptureFailed("Invalid pixel format".to_string())),
+            },
+            &qh,
+            ());
+
+        // copy frame to buffer
+        frame.copy(&buffer);
+
+        // wait for ready or failed
+        event_queue.roundtrip(&mut dispatch_state).map_err(|e| CaptureError::WaylandError(e.to_string()))?;
+
+        let pixel_data = unsafe {
+            std::slice::from_raw_parts(ptr as *const u8, size)
+        }.to_vec();
+
+        unsafe {
+            libc::munmap(ptr, size);
+        }
+
+        {
+            let mut state_lock = shared_state.lock().unwrap();
+            if let CaptureState::Ready(ref mut pixel_buffer) = *state_lock {
+                pixel_buffer.data = pixel_data;
+            }
+        }
+
+        let final_state = Arc::try_unwrap(shared_state).map_err(|_| CaptureError::CaptureFailed("Failed to unwrap shared state".to_string()))?.into_inner().unwrap();
+        match final_state {
+            CaptureState::Ready(pixel_buffer) => Ok(pixel_buffer),
+            CaptureState::Failed => Err(CaptureError::CaptureFailed("Capture failed".to_string())),
+            _ => Err(CaptureError::CaptureFailed("Unexpected capture state".to_string())),
+        }
+    }
+}

--- a/src/wayland_capture/capture/types.rs
+++ b/src/wayland_capture/capture/types.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 Ahmed Wafdy <ahmedadelwafdy782@gmail.com>. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CaptureError {
+    #[error("SHM allocation failed: {0}")]
+    ShmAllocationFailed(#[from] std::io::Error),
+    #[error("Wayland error: {0}")]
+    WaylandError(String),
+    #[error("Capture failed: {0}")]
+    CaptureFailed(String),
+}
+
+// Pixel format of the captured frame. Mirrioring the wl_shm_format on embedded targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PixelFormat {
+    Xrgb8888,
+    Argb8888,
+    Xbgr8888,
+    Abgr8888,
+    Rgb565,
+    Invalid,
+    /// Any format the compositor reported that this crate does not yet name.
+    Unknown(u32),
+}
+
+impl PixelFormat {
+    // Convert a raw u32 format code to a PixelFormat enum variant.
+    pub fn from_raw(raw: u32) -> Self {
+        match raw {
+            0x00000000 => Self::Argb8888,
+            0x00000001 => Self::Xrgb8888,
+            0x34324241 => Self::Abgr8888, // 'AB24'
+            0x34324258 => Self::Xbgr8888, // 'XB24'
+            other      => Self::Unknown(other),
+        }
+    }
+
+    // Returns the number of bytes per pixel for this format, if known.
+    pub fn bytes_per_pixel(self) -> Option<usize> {
+        match self{
+            Self::Argb8888 | Self::Xrgb8888 | Self::Abgr8888 | Self::Xbgr8888 => Some(4),
+            Self::Rgb565 => Some(2),
+            Self::Invalid | Self::Unknown(_) => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PixelBuffer {
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub stride: u32,
+    pub format: PixelFormat,
+}
+
+impl PixelBuffer {
+    // Total Expected size of the pixel buffer in bytes, calculated from width, height, stride, and format. Returns None in overflow.
+    pub fn expected_size(stride: u32, height: u32) -> Option<usize> {
+        let size = (stride as u64).checked_mul(height as u64)? as usize;
+        const MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024 * 1024; // 4 GiB
+        if size > MAX_BUFFER_SIZE {
+            None
+        } else {
+            Some(size)
+        }
+    }
+
+    /// Slice the pixel buffer data into rows based on the stride.
+    pub fn row(&self, y: u32) -> Option<&[u8]> {
+        let start = y.checked_mul(self.stride)? as usize;
+        let end = start.checked_add(self.stride as usize)?;
+        self.data.get(start..end)
+    }
+}
+
+// State machine for a single screencopy frame capture operation.
+// Driven forward by wayland dispatch callbacks.
+#[derive(Debug)]
+pub enum CaptureState {
+    Pending,    // Frame Requested, waiting for compositor buffer event.
+    BufferAllocated {   // Compositor told us the buffer size and format, we allocated a local buffer to receive the data.
+        width: u32,
+        height: u32,
+        stride: u32,
+        format: PixelFormat,
+        data: Vec<u8>,
+    },
+
+    Ready(PixelBuffer), // Buffer is ready to be read by the caller.
+    Failed,
+}
+
+impl CaptureState {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Ready(_) | Self::Failed)
+    }
+
+    pub fn take_buffer(self) -> Option<PixelBuffer> {
+        match self {
+            Self::Ready(buf) => Some(buf),
+            _ => None,
+        }
+    }
+}

--- a/src/wayland_capture/lib.rs
+++ b/src/wayland_capture/lib.rs
@@ -1,0 +1,5 @@
+pub mod capture;
+
+#[cfg(test)]
+mod tests;
+

--- a/src/wayland_capture/tests.rs
+++ b/src/wayland_capture/tests.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+mod pixel_format_tests {
+    use crate::capture::types::PixelFormat;
+
+    #[test]
+    fn known_formats_parse_correctly() {
+        assert_eq!(PixelFormat::from_raw(0x00000000), PixelFormat::Argb8888);
+        assert_eq!(PixelFormat::from_raw(0x00000001), PixelFormat::Xrgb8888);
+        assert_eq!(PixelFormat::from_raw(0x34324241), PixelFormat::Abgr8888);
+        assert_eq!(PixelFormat::from_raw(0x34324258), PixelFormat::Xbgr8888);
+    }
+
+    #[test]
+    fn unknown_format_preserved() {
+        let raw = 0xDEADBEEFu32;
+        assert_eq!(PixelFormat::from_raw(raw), PixelFormat::Unknown(raw));
+    }
+
+    #[test]
+    fn known_formats_report_four_bytes_per_pixel() {
+        let formats: [PixelFormat; 4] = [
+            PixelFormat::Argb8888,
+            PixelFormat::Xrgb8888,
+            PixelFormat::Abgr8888,
+            PixelFormat::Xbgr8888,
+        ];
+        for fmt in formats {
+            assert_eq!(fmt.bytes_per_pixel(), Some(4), "{fmt:?} should be 4 bpp");
+        }
+    }
+
+    #[test]
+    fn unknown_format_has_no_bpp() {
+        assert_eq!(PixelFormat::Unknown(0xFF).bytes_per_pixel(), None);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Wayland screen capture backend as a Rust library, implementing a robust and extensible API for capturing screen contents using the wlr-screencopy protocol. The core logic is organized into a new library crate with well-structured modules for capture operations, error handling, and pixel format management. The implementation includes comprehensive error types, a state machine for capture operations, and a set of unit tests for pixel format handling.

Part of #6 #7 